### PR TITLE
Include missing GH Token in "Ensure Changelog label" workflow

### DIFF
--- a/.github/workflows/ensure_changelog_label.yml
+++ b/.github/workflows/ensure_changelog_label.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "Check for the presence of a changelog label"
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh pr view \
             ${{ github.event.pull_request.number }} \


### PR DESCRIPTION
This PR adds the GitHub Token to a specific job which checks for the presence of the changelog label since is needed to execute the associated GitHub CLI command.

For more information on why this token is needed, refer to: https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows